### PR TITLE
Corrigido logica de LoadBalance Utilizando o Redis como meio.

### DIFF
--- a/docker-server-load-balancing-redis/docker-compose.yaml
+++ b/docker-server-load-balancing-redis/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
           memory: 500M
         reservations:
           memory: 200M
+    depends_on:
+      - redis
     
   wppconnect-server-2:
     build: 
@@ -43,6 +45,7 @@ services:
           memory: 200M
     depends_on:
       - wppconnect-server-1
+      - redis
 
   wppconnect-server-3:
     build: 
@@ -65,6 +68,7 @@ services:
           memory: 200M
     depends_on:
       - wppconnect-server-2
+      - redis
 
   wppconnect-server-4:
     build: 
@@ -87,6 +91,7 @@ services:
           memory: 200M
     depends_on:
       - wppconnect-server-3
+      - redis
 
   wppconnect-server-5:
     build: 
@@ -109,8 +114,10 @@ services:
           memory: 200M
     depends_on:
       - wppconnect-server-4
+      - redis
 
   redis:
+    restart: always
     image: redis
     container_name: redis
     hostname: redis
@@ -119,6 +126,8 @@ services:
     networks: 
       wpp-network:
         ipv4_address: 172.20.0.7
+    volumes:
+      - ./redis-data:/data
   
   wppconnect-nginx:
     build: 

--- a/docker-server-load-balancing-redis/wppconnect-nginx/conf.d/access.lua
+++ b/docker-server-load-balancing-redis/wppconnect-nginx/conf.d/access.lua
@@ -1,29 +1,57 @@
-ngx.log(ngx.WARN,'access_by_lua_block: '..ngx.var.request_uri.. ' :access_by_lua_block;')
+--ngx.log(ngx.WARN,'access_by_lua_block: '..ngx.var.request_uri.. ' :access_by_lua_block;')
+local hosts, ports, redis_server, redis_port = dofile("/etc/nginx/conf.d/hosts.lua")
+local total_server = #hosts --Quantidade de servidor wppconnect
+local controle_load = "posicao/"
 
 local t={}
 for str in string.gmatch(ngx.var.request_uri, "([^".."/".."]+)") do
         table.insert(t, str)
 end
+
+if t[1] ~= 'api' then
+    ngx.say(ngx.ERR, "falha ao tentar ler a URI")
+    return ngx.exit(501)
+end
+
 local session = t[2]
 
 local redis = require "resty.redis"
 local red = redis:new()
 
-local ok, err = red:connect("172.20.0.7", 6379)
-if ok ~= 1 then
-    ngx.say("failed to connect: ", err)
-    return
+local ok, err = red:connect(redis_server, redis_port)
+if not (type(ok) == "string" or type(ok) == "number") then
+    ngx.say("falha ao conectar ao banco redis: ", err)
+    return ngx.exit(501)
 end
 
 local posicao, err = red:get(session)
 if not (type(posicao) == "string" or type(posicao) == "number")  then
-    local novaposicao = math.random( 0, 5 ) --Quantidade de servidor wppconnect
-    local grava, err = red:set(session, novaposicao)
-    if not (type(grava) == "string" or type(grava) == "number")  then
-        ngx.say("failed to set session: ", err)
-        return
+    local posicao_atual, err = red:get(controle_load)
+    if not (type(posicao_atual) == "string" or type(posicao_atual) == "number")  then
+       posicao_atual = 1
+    else
+        posicao_atual = posicao_atual + 1
+        if posicao_atual > total_server then
+            posicao_atual = 1
+        end
     end
-    ngx.header['posicao'] = novaposicao
+
+   local grava, err = red:set(controle_load, posicao_atual)
+   if not (type(grava) == "string" or type(grava) == "number")  then
+       ngx.say("falha ao gravar posicao do servidor: ", err)
+       return ngx.exit(501)
+   end
+
+    local grava, err = red:set(session, posicao_atual)
+    if not (type(grava) == "string" or type(grava) == "number")  then
+        ngx.say("falha ao gravar a posicao da sessão: ", err)
+        return ngx.exit(501)
+    end
+    ngx.header['posicao'] = posicao_atual
 else
     ngx.header['posicao'] = posicao
+end
+
+if t[3] == 'close-session' then
+    red:del(session) 
 end

--- a/docker-server-load-balancing-redis/wppconnect-nginx/conf.d/balance.lua
+++ b/docker-server-load-balancing-redis/wppconnect-nginx/conf.d/balance.lua
@@ -1,24 +1,4 @@
-local hosts = {"172.20.0.2", --IP dos servidores wppconect
-               "172.20.0.3",
-               "172.20.0.4",
-               "172.20.0.5",
-               "172.20.0.6"
-}
-
---[[local hosts = {"wppconnect-server-1",  --Arquivo lua não reconhece pelo nome
-               "wppconnect-server-2",
-               "wppconnect-server-3",
-               "wppconnect-server-4",
-               "wppconnect-server-5"
-}
-]]
-
-local ports = {21465, --Portas dos servidores wppconect
-               21465,
-               21465,
-               21465,
-               21465
-}
+local hosts, ports = dofile("/etc/nginx/conf.d/hosts.lua")
 
 local balancer = require "ngx.balancer"
 local host = hosts[tonumber(ngx.header['posicao'])]

--- a/docker-server-load-balancing-redis/wppconnect-nginx/conf.d/hosts.lua
+++ b/docker-server-load-balancing-redis/wppconnect-nginx/conf.d/hosts.lua
@@ -1,0 +1,18 @@
+local hosts = {"172.20.0.2", --IP dos servidores wppconect
+               "172.20.0.3",
+               "172.20.0.4",
+               "172.20.0.5",
+               "172.20.0.6"
+}
+
+local  ports = {21465, --Portas dos servidores wppconect
+                21465,
+                21465,
+                21465,
+                21465
+}
+
+local redis_server = "172.20.0.7"
+local redis_port = 6379
+
+return hosts, ports, redis_server, redis_port

--- a/docker-server-load-balancing-redis/wppconnect-server/config.json
+++ b/docker-server-load-balancing-redis/wppconnect-server/config.json
@@ -67,6 +67,7 @@
         "redisHost": "172.20.0.7",
         "redisPort": 6379,
         "redisPassword": "",
-        "redisDb": 0
+        "redisDb": 0,
+        "redisPrefix": "docker"
     }
 }

--- a/docker-server-load-balancing-redis/wppconnect-server/config.json
+++ b/docker-server-load-balancing-redis/wppconnect-server/config.json
@@ -3,7 +3,7 @@
     "host": "http://localhost",
     "port": "21465",
     "startAllSession": true,
-    "tokenStoreType": "file",
+    "tokenStoreType": "redis",
     "webhook": {
         "url": null,
         "autoDownload": true,
@@ -52,7 +52,7 @@
         ]
     },
     "mapper": {
-        "enable": false,
+        "enable": true,
         "prefix": "tagone-"
     },
     "db": {
@@ -64,7 +64,7 @@
         "mongoIsRemote": true,
         "mongoURLRemote": "",
         "mongodbPort": 27017,
-        "redisHost": "localhost",
+        "redisHost": "172.20.0.7",
         "redisPort": 6379,
         "redisPassword": "",
         "redisDb": 0


### PR DESCRIPTION
Corrigido a logica do LoadBalance pela nginx-lua utilizando o banco redis para armazenar as posições.
Alterado o conf para utilizar a rotina de colocar o ip na chave do redis.
Adicionado volume na criação do banco redis, assim armazenando mesmo se fizer um build novamente.