### PR TITLE
Hotfix do config.ts para corrigir problema do commit 7324610 do wpp-c…

### DIFF
--- a/docker-server-chatwoot/wppconnect-server/config.ts
+++ b/docker-server-chatwoot/wppconnect-server/config.ts
@@ -23,6 +23,10 @@ export default {
     onLabelUpdated: true,
     onSelfMessage: false,
   },
+  websocket: {
+    autoDownload: false,
+    uploadS3: false,
+  },
   chatwoot: {
     sendQrCode: true,
     sendStatus: true,


### PR DESCRIPTION
…onnect-server

Após as alterações do commit 7324610 de 04 de Novembro de  2023, ocorria um erro ao executar o comando yarn build durante o processo de criação do container:

 `src/util/functions.ts(41,13): error TS2339: Property 'websocket' does not exist on type '{ secretKey: string; host: string; port: string; deviceName: string; poweredBy: string; startAllSession: boolean; tokenStoreType: string; maxListeners: number; customUserDataDir: string; webhook: { ...; }; ... 6 more ...; aws_s3: { ...; }; }'.`

Ficou faltando adicionar a opção de websocket no arquivo para poder construir o container.